### PR TITLE
Allows validation to fail, even when the validators do not add errors…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 # Idea
 *.iml
 .idea
+fluent-validator/target/

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/ComplexResult.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/ComplexResult.java
@@ -1,11 +1,17 @@
 package com.baidu.unbiz.fluentvalidator;
 
+import java.util.List;
+
 /**
  * 带有全信息的复杂验证结果
  *
  * @author zhangxu
  */
 public class ComplexResult extends GenericResult<ValidationError> {
+
+    public ComplexResult(boolean success, List<ValidationError> errors) {
+        super(success, errors);
+    }
 
     @Override
     public String toString() {

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/GenericResult.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/GenericResult.java
@@ -1,5 +1,6 @@
 package com.baidu.unbiz.fluentvalidator;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.baidu.unbiz.fluentvalidator.util.CollectionUtil;
@@ -22,6 +23,16 @@ public abstract class GenericResult<T> {
      * 错误消息列表
      */
     protected List<T> errors;
+
+    public GenericResult() {
+        isSuccess = true;
+        errors = new ArrayList<T>();
+    }
+
+    public GenericResult(boolean isSuccess, List<T> errors) {
+        this.isSuccess = isSuccess;
+        this.errors = errors;
+    }
 
     @Override
     public String toString() {

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/Result.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/Result.java
@@ -1,5 +1,7 @@
 package com.baidu.unbiz.fluentvalidator;
 
+import java.util.List;
+
 /**
  * 最简单的验证结果
  * <p/>
@@ -8,5 +10,4 @@ package com.baidu.unbiz.fluentvalidator;
  * @author zhangxu
  */
 public class Result extends GenericResult<String> {
-
 }

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/ResultCollectors.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/ResultCollectors.java
@@ -3,6 +3,8 @@ package com.baidu.unbiz.fluentvalidator;
 import com.baidu.unbiz.fluentvalidator.util.CollectionUtil;
 import com.baidu.unbiz.fluentvalidator.util.Function;
 
+import java.util.ArrayList;
+
 /**
  * 框架自身实现的一个简单的验证结果收集器
  *
@@ -43,14 +45,7 @@ public class ResultCollectors {
 
         @Override
         public ComplexResult toResult(ValidationResult result) {
-            ComplexResult ret = new ComplexResult();
-            if (result.isSuccess()) {
-                ret.setIsSuccess(true);
-            } else {
-                ret.setIsSuccess(false);
-                ret.setErrors(result.getErrors());
-            }
-
+            ComplexResult ret = new ComplexResult(result.isSuccess(), result.getErrors());
             ret.setTimeElapsed(result.getTimeElapsed());
             return ret;
         }

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/ValidationResult.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/ValidationResult.java
@@ -1,5 +1,6 @@
 package com.baidu.unbiz.fluentvalidator;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.baidu.unbiz.fluentvalidator.annotation.NotThreadSafe;
@@ -22,7 +23,7 @@ public class ValidationResult {
     /**
      * 验证错误
      */
-    private List<ValidationError> errors;
+    private List<ValidationError> errors = new ArrayList<ValidationError>();
 
     /**
      * 验证总体耗时，指通过<code>FluentValidator.doValidate(..)</code>真正“及时求值”过程中的耗时

--- a/fluent-validator/src/test/java/com/baidu/unbiz/fluentvalidator/FluentValidatorWIthoutAnnotationsTest.java
+++ b/fluent-validator/src/test/java/com/baidu/unbiz/fluentvalidator/FluentValidatorWIthoutAnnotationsTest.java
@@ -1,0 +1,111 @@
+package com.baidu.unbiz.fluentvalidator;
+
+import com.baidu.unbiz.fluentvalidator.annotation.FluentValid;
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FluentValidatorWIthoutAnnotationsTest {
+
+    class Passenger {
+        String name;
+        Boolean hasSeatbeltOn;
+
+        public Passenger(String name, Boolean hasSeatbeltOn) {
+            this.name = name;
+            this.hasSeatbeltOn = hasSeatbeltOn;
+        }
+    }
+
+    class Car {
+        private String make;
+        private List<Passenger> passengers = Lists.newArrayList();
+
+        public void addPassenger(Passenger passenger) {
+            passengers.add(passenger);
+        }
+    }
+
+    class SeatBeltValidator extends ValidatorHandler<Boolean> implements Validator<Boolean> {
+        private String name;
+
+        public SeatBeltValidator(String name) {
+            this.name = name;
+        }
+
+        public boolean validate(ValidatorContext context, Boolean hasSeatbeltOn) {
+            if (!hasSeatbeltOn) {
+                ValidationError error = new ValidationError();
+                error.setErrorCode(123);
+                error.setErrorMsg("passenger " + name + " must have their seat belt on");
+                context.addError(error);
+            }
+
+            return hasSeatbeltOn;
+        }
+    }
+
+    class SeatBeltValidatorWithoutError extends ValidatorHandler<Boolean> implements Validator<Boolean> {
+        public boolean validate(ValidatorContext context, Boolean hasSeatbeltOn) {
+            return hasSeatbeltOn;
+        }
+    }
+
+    class PassengerValidator extends ValidatorHandler<Passenger> implements Validator<Passenger> {
+        @Override
+        public boolean validate(ValidatorContext context, Passenger passenger) {
+            ComplexResult result = FluentValidator
+                    .checkAll()
+                    .on(passenger.hasSeatbeltOn, new SeatBeltValidator(passenger.name))
+                    .on(passenger.hasSeatbeltOn, new SeatBeltValidatorWithoutError())
+                    .failOver()
+                    .doValidate()
+                    .result(ResultCollectors.toComplex());
+
+            for (ValidationError error : result.getErrors()) {
+                context.addError(error);
+            }
+
+            return result.isSuccess();
+        }
+    }
+
+    class CarValidator extends ValidatorHandler<Car> implements Validator<Car> {
+        @Override
+        public boolean validate(ValidatorContext context, Car car) {
+            ComplexResult result = FluentValidator
+                    .checkAll()
+                    .onEach(car.passengers, new PassengerValidator())
+                    .failOver()
+                    .doValidate()
+                    .result(ResultCollectors.toComplex());
+
+            for (ValidationError error : result.getErrors()) {
+                context.addError(error);
+            }
+
+            return result.isSuccess();
+        }
+    }
+
+    @Test
+    public void itCanValidateComplexObjects() {
+        Car car = new Car();
+        car.addPassenger(new Passenger("Adam", false));
+        car.addPassenger(new Passenger("Joe", true));
+
+        ComplexResult result = FluentValidator
+                .checkAll()
+                .on(car, new CarValidator())
+                .failOver()
+                .doValidate()
+                .result(ResultCollectors.toComplex());
+
+        assertThat(result.getErrors().size(), equalTo(1));
+        assertThat(result.getErrors().get(0).getErrorMsg(), equalTo("passenger Adam must have their seat belt on"));
+    }
+}


### PR DESCRIPTION
… to the context.

Sometimes a result would get created without initializing its errors list.
The default constructor for a result now sets up an empty list. In the
complex result collection, we use a constructor to setup the errors list.