### PR TITLE
Extends the Validator interface to allow for composition of validations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 # Idea
 *.iml
 .idea
+
+fluent-validator/target

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/FluentValidator.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/FluentValidator.java
@@ -334,6 +334,9 @@ public class FluentValidator {
      */
     public <T> FluentValidator on(T t, Validator<T> v) {
         Preconditions.checkNotNull(v, "Validator should not be NULL");
+        v.setCurrent(this);
+        v.compose(this, context, t);
+
         doAdd(new ValidatorElement(t, v));
         lastAddCount = 1;
         return this;
@@ -353,6 +356,7 @@ public class FluentValidator {
             lastAddCount = 0;
         } else {
             for (Validator v : chain.getValidators()) {
+                v.setCurrent(this);
                 doAdd(new ValidatorElement(t, v));
             }
             lastAddCount = chain.getValidators().size();
@@ -393,12 +397,16 @@ public class FluentValidator {
      */
     public <T> FluentValidator onEach(Collection<T> t, final Validator<T> v) {
         Preconditions.checkNotNull(v, "Validator should not be NULL");
+        v.setCurrent(this);
+        final FluentValidator self = this;
+
         if (CollectionUtil.isEmpty(t)) {
             lastAddCount = 0;
         } else {
             List<ValidatorElement> elementList = CollectionUtil.transform(t, new Function<T, ValidatorElement>() {
                 @Override
                 public ValidatorElement apply(T elem) {
+                    v.compose(self, context, elem);
                     return new ValidatorElement(elem, v);
                 }
             });

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/GenericResult.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/GenericResult.java
@@ -1,5 +1,6 @@
 package com.baidu.unbiz.fluentvalidator;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.baidu.unbiz.fluentvalidator.util.CollectionUtil;
@@ -21,7 +22,7 @@ public abstract class GenericResult<T> {
     /**
      * 错误消息列表
      */
-    protected List<T> errors;
+    protected List<T> errors = new ArrayList<T>();
 
     @Override
     public String toString() {

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/Validator.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/Validator.java
@@ -45,4 +45,11 @@ public interface Validator<T> {
      */
     void onException(Exception e, ValidatorContext context, T t);
 
+
+    void setCurrent(FluentValidator current);
+
+    //
+    // Add an extension point for validators to add to the current
+    //
+    void compose(FluentValidator current, ValidatorContext context, T t);
 }

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/ValidatorHandler.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/ValidatorHandler.java
@@ -13,6 +13,8 @@ import com.baidu.unbiz.fluentvalidator.annotation.ThreadSafe;
 @ThreadSafe
 public class ValidatorHandler<T> implements Validator<T> {
 
+    private FluentValidator current;
+
     @Override
     public boolean accept(ValidatorContext context, T t) {
         return true;
@@ -26,6 +28,16 @@ public class ValidatorHandler<T> implements Validator<T> {
     @Override
     public void onException(Exception e, ValidatorContext context, T t) {
 
+    }
+
+    @Override
+    public void setCurrent(FluentValidator current) {
+        this.current = current;
+    }
+
+    @Override
+    public void compose(FluentValidator current, ValidatorContext context, T t) {
+        // extension point for clients to add more validators to the current fluent chain
     }
 
     /**

--- a/fluent-validator/src/test/java/com/baidu/unbiz/fluentvalidator/FluentValidatorWIthNestedValidationRules.java
+++ b/fluent-validator/src/test/java/com/baidu/unbiz/fluentvalidator/FluentValidatorWIthNestedValidationRules.java
@@ -1,0 +1,86 @@
+package com.baidu.unbiz.fluentvalidator;
+
+import com.baidu.unbiz.fluentvalidator.util.Function;
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FluentValidatorWIthNestedValidationRules {
+    class Passenger {
+        String name;
+        Boolean hasSeatbeltOn;
+
+        public Passenger(String name, Boolean hasSeatbeltOn) {
+            this.name = name;
+            this.hasSeatbeltOn = hasSeatbeltOn;
+        }
+    }
+
+    class Car {
+        private String make;
+        private List<Passenger> passengers = Lists.newArrayList();
+
+        public void addPassenger(Passenger passenger) {
+            passengers.add(passenger);
+        }
+    }
+
+    class SeatBeltValidator extends ValidatorHandler<Boolean> implements Validator<Boolean> {
+        private String name;
+
+        public SeatBeltValidator(String name) {
+            this.name = name;
+        }
+
+        public boolean validate(ValidatorContext context, Boolean hasSeatbeltOn) {
+            if (!hasSeatbeltOn) {
+                ValidationError error = new ValidationError();
+                error.setErrorCode(123);
+                error.setErrorMsg("passenger " + name + " must have their seat belt on");
+                context.addError(error);
+            }
+
+            return hasSeatbeltOn;
+        }
+    }
+
+    class SeatBeltValidatorWithoutError extends ValidatorHandler<Boolean> implements Validator<Boolean> {
+        public boolean validate(ValidatorContext context, Boolean hasSeatbeltOn) {
+            return hasSeatbeltOn;
+        }
+    }
+
+    class PassengerValidator extends ValidatorHandler<Passenger> implements Validator<Passenger> {
+        public void compose(FluentValidator current, ValidatorContext context, final Passenger passenger) {
+            current.on(passenger.hasSeatbeltOn, new SeatBeltValidator(passenger.name));
+        }
+    }
+
+    class CarValidator extends ValidatorHandler<Car> implements Validator<Car> {
+        public void compose(FluentValidator current, ValidatorContext context, final Car car) {
+            current.onEach(car.passengers, new PassengerValidator());
+        }
+    }
+
+    @Test
+    public void itCanValidateComplexObjects() {
+        Car car = new Car();
+        car.addPassenger(new Passenger("Adam", false));
+        car.addPassenger(new Passenger("Joe", true));
+
+        ComplexResult result = FluentValidator
+                .checkAll()
+                .on(car, new CarValidator())
+                .failOver()
+                .doValidate()
+                .result(ResultCollectors.toComplex());
+
+        assertThat(result.getErrors().size(), equalTo(1));
+        assertThat(result.getErrors().get(0).getErrorMsg(), equalTo("passenger Adam must have their seat belt on"));
+    }
+}
+


### PR DESCRIPTION
Currently, validators have no way of adding more validation rules to the current
context. FluentValidator instances add themselves to each validator, and the
implementation of each `on` operation will ensure that compose gets called for
each validator.

--

Again, we're looking for feedback on this approach. We can tidy up the implementation to make it more robust if you like where we're headed.