### PR TITLE
Customize error message for `on` method of FluentValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In order to use Fluent Validator within a Maven project, simply add the followin
 	<dependency>
     	<groupId>com.baidu.unbiz</groupId>
     	<artifactId>fluent-validator</artifactId>
-    	<version>1.0.5</version>
+    	<version>1.0.6</version>
 	</dependency>
 
 *Check out the lastest version on [Maven Central](https://search.maven.org/#search%7Cga%7C1%7Cfluent-validator).*
@@ -527,7 +527,7 @@ Add the following dependency to your pom.xml.
 	<dependency>
     	<groupId>com.baidu.unbiz</groupId>
     	<artifactId>fluent-validator-jsr303</artifactId>
-    	<version>1.0.5</version>
+    	<version>1.0.6</version>
 	</dependency>
 	
 By default, the following dependencies are what fluent-validator-jsr303 will bring into your project. 
@@ -668,7 +668,7 @@ To use `SpringApplicationContextRegistry`, add the following dependency to your 
 	<dependency>
     	<groupId>com.baidu.unbiz</groupId>
     	<artifactId>fluent-validator-spring</artifactId>
-    	<version>1.0.5</version>
+    	<version>1.0.6</version>
 	</dependency>
 	
 By default, the following dependencies are what fluent-validator-spring will bring into your project. 

--- a/fluent-validator-demo/pom.xml
+++ b/fluent-validator-demo/pom.xml
@@ -7,12 +7,12 @@
         <groupId>com.baidu.unbiz</groupId>
         <artifactId>fluent-validator-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
     </parent>
 
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>fluent-validator-demo</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>fluent-validator-demo</name>
     <description>A simple Java validation framework leveraging fluent interface style and JSR 303 specification
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.baidu.unbiz</groupId>
             <artifactId>fluent-validator-spring</artifactId>
-            <version>1.0.6-SNAPSHOT</version>
+            <version>1.0.7-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/fluent-validator-jsr303/pom.xml
+++ b/fluent-validator-jsr303/pom.xml
@@ -6,12 +6,12 @@
         <groupId>com.baidu.unbiz</groupId>
         <artifactId>fluent-validator-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.6</version>
+        <version>1.0.6-SNAPSHOT</version>
     </parent>
 
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>fluent-validator-jsr303</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>fluent-validator-jsr303</name>
     <description>A simple Java validation framework leveraging fluent interface style and JSR 303 specification
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.baidu.unbiz</groupId>
             <artifactId>fluent-validator</artifactId>
-            <version>1.0.6</version>
+            <version>1.0.6-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/fluent-validator-jsr303/pom.xml
+++ b/fluent-validator-jsr303/pom.xml
@@ -6,12 +6,12 @@
         <groupId>com.baidu.unbiz</groupId>
         <artifactId>fluent-validator-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
     </parent>
 
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>fluent-validator-jsr303</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>fluent-validator-jsr303</name>
     <description>A simple Java validation framework leveraging fluent interface style and JSR 303 specification
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.baidu.unbiz</groupId>
             <artifactId>fluent-validator</artifactId>
-            <version>1.0.6-SNAPSHOT</version>
+            <version>1.0.7-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/fluent-validator-spring/pom.xml
+++ b/fluent-validator-spring/pom.xml
@@ -6,12 +6,12 @@
         <groupId>com.baidu.unbiz</groupId>
         <artifactId>fluent-validator-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.6</version>
+        <version>1.0.6-SNAPSHOT</version>
     </parent>
 
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>fluent-validator-spring</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>fluent-validator-spring</name>
     <description>A simple Java validation framework leveraging fluent interface style and JSR 303 specification
@@ -21,13 +21,13 @@
         <dependency>
             <groupId>com.baidu.unbiz</groupId>
             <artifactId>fluent-validator</artifactId>
-            <version>1.0.6</version>
+            <version>1.0.6-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.baidu.unbiz</groupId>
             <artifactId>fluent-validator-jsr303</artifactId>
-            <version>1.0.6</version>
+            <version>1.0.6-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/fluent-validator-spring/pom.xml
+++ b/fluent-validator-spring/pom.xml
@@ -6,12 +6,12 @@
         <groupId>com.baidu.unbiz</groupId>
         <artifactId>fluent-validator-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
     </parent>
 
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>fluent-validator-spring</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>fluent-validator-spring</name>
     <description>A simple Java validation framework leveraging fluent interface style and JSR 303 specification
@@ -21,13 +21,13 @@
         <dependency>
             <groupId>com.baidu.unbiz</groupId>
             <artifactId>fluent-validator</artifactId>
-            <version>1.0.6-SNAPSHOT</version>
+            <version>1.0.7-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>com.baidu.unbiz</groupId>
             <artifactId>fluent-validator-jsr303</artifactId>
-            <version>1.0.6-SNAPSHOT</version>
+            <version>1.0.6</version>
         </dependency>
 
         <dependency>

--- a/fluent-validator/pom.xml
+++ b/fluent-validator/pom.xml
@@ -6,12 +6,12 @@
         <groupId>com.baidu.unbiz</groupId>
         <artifactId>fluent-validator-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.6</version>
+        <version>1.0.6-SNAPSHOT</version>
     </parent>
 
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>fluent-validator</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>fluent-validator</name>
     <description>A simple Java validation framework leveraging fluent interface style and JSR 303 specification

--- a/fluent-validator/pom.xml
+++ b/fluent-validator/pom.xml
@@ -6,12 +6,12 @@
         <groupId>com.baidu.unbiz</groupId>
         <artifactId>fluent-validator-parent</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.7-SNAPSHOT</version>
     </parent>
 
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>fluent-validator</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>fluent-validator</name>
     <description>A simple Java validation framework leveraging fluent interface style and JSR 303 specification

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/ValidatorContext.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/ValidatorContext.java
@@ -2,8 +2,11 @@ package com.baidu.unbiz.fluentvalidator;
 
 import java.util.Map;
 
+import com.baidu.unbiz.fluentvalidator.annotation.Nullable;
 import com.baidu.unbiz.fluentvalidator.util.CollectionUtil;
+import com.baidu.unbiz.fluentvalidator.util.ThreadContext;
 
+import static com.baidu.unbiz.fluentvalidator.util.ThreadContext.VALIDATOR_MESSAGE;
 /**
  * 验证器执行调用中的上下文
  * <p/>
@@ -121,5 +124,18 @@ public class ValidatorContext {
      */
     public void setResult(ValidationResult result) {
         this.result = result;
+    }
+
+    /**
+     * 返回默认的一些message，一般通过如下形式注入到context中使用
+     * <pre>
+     *     fv.on(car.getLicensePlate(), new CarLicensePlateValidator(),"Car License Plate Validator is Good")
+     * </pre>
+     *
+     * @return 默认信息，可为null
+     */
+    @Nullable
+    public String getDefaultMessage() {
+        return ThreadContext.getContext(VALIDATOR_MESSAGE);
     }
 }

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/annotation/Nullable.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/annotation/Nullable.java
@@ -1,0 +1,15 @@
+package com.baidu.unbiz.fluentvalidator.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * 标记为可为空的注解
+ *
+ * @author zhangxu
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Nullable {
+
+}

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/util/ThreadContext.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/util/ThreadContext.java
@@ -1,0 +1,105 @@
+package com.baidu.unbiz.fluentvalidator.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 线程执行的上下文内容
+ */
+public class ThreadContext {
+
+    public static final String VALIDATOR_MESSAGE = "validator_message";
+
+    /**
+     * 线程上下文变量的持有者
+     */
+    private final static ThreadLocal<Map<String, Object>> CTX_HOLDER = new ThreadLocal<Map<String, Object>>();
+
+//    static {
+//        CTX_HOLDER.set(new HashMap<String, Object>());
+//    }
+
+    /**
+     * 添加内容到线程上下文中
+     *
+     * @param key
+     * @param value
+     */
+    public final static void putContext(String key, Object value) {
+        Map<String, Object> ctx = CTX_HOLDER.get();
+        if (ctx == null) {
+            ctx = new HashMap<String, Object>();
+            CTX_HOLDER.set(ctx);
+        }
+        ctx.put(key, value);
+    }
+
+    /**
+     * 从线程上下文中获取内容
+     *
+     * @param key
+     */
+    @SuppressWarnings("unchecked")
+    public final static <T extends Object> T getContext(String key) {
+        Map<String, Object> ctx = CTX_HOLDER.get();
+        if (ctx == null) {
+            return null;
+        }
+        return (T) ctx.get(key);
+    }
+
+    /**
+     * 获取线程上下文
+     *
+     * @param key
+     */
+    public final static Map<String, Object> getContext() {
+        Map<String, Object> ctx = CTX_HOLDER.get();
+        if (ctx == null) {
+            return null;
+        }
+        return ctx;
+    }
+
+    /**
+     * 删除上下文中的key
+     *
+     * @param key
+     */
+    public final static void remove(String key) {
+        Map<String, Object> ctx = CTX_HOLDER.get();
+        if (ctx != null) {
+            ctx.remove(key);
+        }
+    }
+
+    /**
+     * 上下文中是否包含此key
+     *
+     * @param key
+     * @return
+     */
+    public final static boolean contains(String key) {
+        Map<String, Object> ctx = CTX_HOLDER.get();
+        if (ctx != null) {
+            return ctx.containsKey(key);
+        }
+        return false;
+    }
+
+
+    /**
+     * 清空线程上下文
+     */
+    public final static void clean() {
+        CTX_HOLDER.set(null);
+    }
+
+    /**
+     * 初始化线程上下文
+     */
+    public final static void init() {
+        CTX_HOLDER.set(new HashMap<String, Object>());
+    }
+
+}

--- a/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/validator/element/ValidatorElement.java
+++ b/fluent-validator/src/main/java/com/baidu/unbiz/fluentvalidator/validator/element/ValidatorElement.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.baidu.unbiz.fluentvalidator.FluentValidator;
 import com.baidu.unbiz.fluentvalidator.Validator;
+import com.baidu.unbiz.fluentvalidator.ValidatorContext;
 import com.baidu.unbiz.fluentvalidator.able.ListAble;
 import com.baidu.unbiz.fluentvalidator.able.ToStringable;
 
@@ -31,6 +32,16 @@ public class ValidatorElement implements ListAble<ValidatorElement> {
     private ToStringable customizedToString;
 
     /**
+     * 默认的错误信息，用于直接在fluent的链条上直接指定错误，如下所示
+     * <pre>
+     *     fv.on(car.getLicensePlate(), new CarLicensePlateValidator(),"Car License Plate Validator is Good")
+     * </pre>
+     * 在{@link Validator#validate(ValidatorContext, Object)}可以直接通过context获取message，
+     * 例如{@link ValidatorContext#getDefaultMessage()}。
+     */
+    private String message;
+
+    /**
      * create
      *
      * @param target    待验证对象
@@ -39,6 +50,19 @@ public class ValidatorElement implements ListAble<ValidatorElement> {
     public ValidatorElement(Object target, Validator validator) {
         this.target = target;
         this.validator = validator;
+    }
+
+    /**
+     * create
+     *
+     * @param target    待验证对象
+     * @param validator 验证器
+     * @param message   默认的关联此validator的信息，一般是默认的错误信息
+     */
+    public ValidatorElement(Object target, Validator validator, String message) {
+        this.target = target;
+        this.validator = validator;
+        this.message = message;
     }
 
     /**
@@ -61,6 +85,10 @@ public class ValidatorElement implements ListAble<ValidatorElement> {
 
     public Validator getValidator() {
         return validator;
+    }
+
+    public String getMessage() {
+        return message;
     }
 
     @Override

--- a/fluent-validator/src/test/java/com/baidu/unbiz/fluentvalidator/FluentValidatorCascadeTest.java
+++ b/fluent-validator/src/test/java/com/baidu/unbiz/fluentvalidator/FluentValidatorCascadeTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.fail;
 
 import java.util.List;
 
+import com.baidu.unbiz.fluentvalidator.validator.CustomNullCheckValidator;
 import org.junit.Test;
 
 import com.baidu.unbiz.fluentvalidator.dto.Car;
@@ -90,7 +91,7 @@ public class FluentValidatorCascadeTest {
         Garage garage = getGarage();
         List<Car> cars = getValidCars();
         cars.get(0).setLicensePlate("BEIJING123");
-        garage.setArrayCar(cars.toArray(new Car[] {}));
+        garage.setArrayCar(cars.toArray(new Car[]{}));
 
         Result ret = FluentValidator.checkAll()
                 .on(garage)
@@ -111,7 +112,7 @@ public class FluentValidatorCascadeTest {
 
         List<Car> cars2 = getValidCars();
         cars2.get(0).setSeatCount(0);
-        garage.setArrayCar(cars2.toArray(new Car[] {}));
+        garage.setArrayCar(cars2.toArray(new Car[]{}));
 
         Result ret = FluentValidator.checkAll().failOver()
                 .on(garage)
@@ -174,10 +175,42 @@ public class FluentValidatorCascadeTest {
         assertThat(ret.isSuccess(), is(false));
     }
 
+    @Test
+    public void testGarageWithDefaultErrorMessage() {
+        Garage garage = null;
+        Result ret = FluentValidator.checkAll()
+                .on(garage, new CustomNullCheckValidator(), "Garage Object is Null")
+                .doValidate()
+                .result(toSimple());
+        System.out.println(ret);
+        assertThat(ret.isSuccess(), is(false));
+        assertThat(ret.errors, is((List) Lists.newArrayList(
+                "Garage Object is Null"
+        )));
+    }
+
+    @Test
+    public void testGarageWithMultipleDefaultErrorMessage() {
+        Car c = new Car(null, null, 10);
+        Result ret = FluentValidator.checkAll().failOver()
+                .on(c, new CustomNullCheckValidator(), "Car Object is Null")
+                .on(c.getLicensePlate(), new CustomNullCheckValidator(), "Car License is Null")
+                .on(c.getManufacturer(), new CustomNullCheckValidator(), "Car Manufacture is Null")
+                .on(c.getSeatCount())
+                .doValidate()
+                .result(toSimple());
+        System.out.println(ret);
+        assertThat(ret.isSuccess(), is(false));
+        assertThat(ret.errors, is((List) Lists.newArrayList(
+                "Car License is Null",
+                "Car Manufacture is Null"
+        )));
+    }
+
     private Garage getGarage() {
         Garage garage = new Garage();
         garage.setCollectionCar(getValidCars());
-        garage.setArrayCar(getValidCars().toArray(new Car[] {}));
+        garage.setArrayCar(getValidCars().toArray(new Car[]{}));
         garage.setSingleCar(getValidCar());
         garage.setStr("abc");
         return garage;

--- a/fluent-validator/src/test/java/com/baidu/unbiz/fluentvalidator/QuickValidatorTest.java
+++ b/fluent-validator/src/test/java/com/baidu/unbiz/fluentvalidator/QuickValidatorTest.java
@@ -127,9 +127,6 @@ public class QuickValidatorTest {
 
         @Override
         public boolean validate(ValidatorContext context, final Car car) {
-            // Pass the context to QuickValidator to create a new FluentValidator instance,
-            // so that validation result can be set within the same context,
-            // or you can consider the context to be shared.
             return QuickValidator.doAndGetComplexResult(new Decorator() {
                 @Override
                 public FluentValidator decorate(FluentValidator fv) {

--- a/fluent-validator/src/test/java/com/baidu/unbiz/fluentvalidator/validator/CustomNullCheckValidator.java
+++ b/fluent-validator/src/test/java/com/baidu/unbiz/fluentvalidator/validator/CustomNullCheckValidator.java
@@ -1,0 +1,18 @@
+package com.baidu.unbiz.fluentvalidator.validator;
+
+
+import com.baidu.unbiz.fluentvalidator.Validator;
+import com.baidu.unbiz.fluentvalidator.ValidatorContext;
+import com.baidu.unbiz.fluentvalidator.ValidatorHandler;
+
+public class CustomNullCheckValidator extends ValidatorHandler<Object> implements Validator<Object> {
+
+    @Override
+    public boolean validate(ValidatorContext context, Object t) {
+        if (t == null) {
+            context.addErrorMsg(context.getDefaultMessage());
+            return false;
+        }
+        return true;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>fluent-validator-parent</artifactId>
-    <version>1.0.6</version>
+    <version>1.0.6-SNAPSHOT</version>
     <name>fluent-validator-parent</name>
     <packaging>pom</packaging>
     <description>A simple Java validation framework leveraging fluent interface style and JSR 303 specification

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.baidu.unbiz</groupId>
     <artifactId>fluent-validator-parent</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <name>fluent-validator-parent</name>
     <packaging>pom</packaging>
     <description>A simple Java validation framework leveraging fluent interface style and JSR 303 specification


### PR DESCRIPTION
support customized error message on `on(target, "there is message")` method, so that validator could use default error message through context. This is enhancement feature from github user ganeshpanruti.
